### PR TITLE
fix: custom daily seeds will save the config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ secret.key
 *.iml
 *.ipr
 *.iws
-.vscode/launch.json
+.vscode/
 
 /.vs

--- a/defs/savedata.go
+++ b/defs/savedata.go
@@ -99,7 +99,7 @@ type SessionSaveData struct {
 	Seed                     string                   `json:"seed"`
 	PlayTime                 int                      `json:"playTime"`
 	GameMode                 GameMode                 `json:"gameMode"`
-	DailyConfig              DailyConfig              `json:"dailyConfig"`
+	DailyConfig              DailyConfig              `json:"dailyConfig,omitempty"`
 	Party                    []PokemonData            `json:"party"`
 	EnemyParty               []PokemonData            `json:"enemyParty"`
 	Modifiers                []PersistentModifierData `json:"modifiers"`

--- a/defs/savedata.go
+++ b/defs/savedata.go
@@ -99,6 +99,7 @@ type SessionSaveData struct {
 	Seed                     string                   `json:"seed"`
 	PlayTime                 int                      `json:"playTime"`
 	GameMode                 GameMode                 `json:"gameMode"`
+	DailyConfig              DailyConfig              `json:"dailyConfig"`
 	Party                    []PokemonData            `json:"party"`
 	EnemyParty               []PokemonData            `json:"enemyParty"`
 	Modifiers                []PersistentModifierData `json:"modifiers"`
@@ -150,6 +151,8 @@ type MysteryEncounterSaveData struct {
 }
 
 type GameMode int
+
+type DailyConfig interface{}
 
 type PokemonData interface{}
 


### PR DESCRIPTION
Custom seeds didn't save their config since  rogueserver didn't know the new `dailyConfig` sessionData field.
This PR fixes that.

[Main PR that added the new field](https://github.com/pagefaultgames/pokerogue/pull/6758)

<details><summary>Before (on beta)</summary>

https://github.com/user-attachments/assets/5cdc6b42-eb9e-44d1-a677-8aac3251b968

</details> 

<details><summary>Fixed (on local)</summary>

https://github.com/user-attachments/assets/90194e66-65ac-494c-8f1b-16b77b0d0a40

</details> 
