### PR TITLE
feat: enforce minimum game version of `1.12.0.1` for clients

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -355,12 +355,22 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		cmp, err := savedata.CompareGameVersion(oldSystem.GameVersion, data.System.GameVersion)
+		minVerCmp, err := savedata.CompareGameVersion("1.12.0.1", data.System.GameVersion)
 		if err != nil {
 			httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
 			return
 		}
-		if cmp > 0 {
+		if minVerCmp > 0 {
+			httpError(w, r, fmt.Errorf("session out of date: save version below minimum game version"), http.StatusBadRequest)
+			return
+		}
+
+		saveVerCmp, err := savedata.CompareGameVersion(oldSystem.GameVersion, data.System.GameVersion)
+		if err != nil {
+			httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
+			return
+		}
+		if saveVerCmp > 0 {
 			httpError(w, r, fmt.Errorf("session out of date: existing version is greater"), http.StatusBadRequest)
 			return
 		}
@@ -476,12 +486,22 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			cmp, err := savedata.CompareGameVersion(oldSystem.GameVersion, system.GameVersion)
+			minVerCmp, err := savedata.CompareGameVersion("1.12.0.1", system.GameVersion)
 			if err != nil {
 				httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
 				return
 			}
-			if cmp > 0 {
+			if minVerCmp > 0 {
+				httpError(w, r, fmt.Errorf("session out of date: save version below minimum game version"), http.StatusBadRequest)
+				return
+			}
+
+			saveVerCmp, err := savedata.CompareGameVersion(oldSystem.GameVersion, system.GameVersion)
+			if err != nil {
+				httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
+				return
+			}
+			if saveVerCmp > 0 {
 				httpError(w, r, fmt.Errorf("session out of date: existing version is greater"), http.StatusBadRequest)
 				return
 			}


### PR DESCRIPTION
Clients attempting to upload save data from `1.12.0.0` or earlier will have their save rejected.

Tested with the server running locally, a save from `1.12.0.1` was allowed and saves from `1.12.0.0` and `1.11.22` were rejected.

<details><summary>Network response for 1.12.0.0 save request</summary>

<img width="684" height="166" alt="image" src="https://github.com/user-attachments/assets/50067caa-15ed-4c19-a090-850b9bfdf485" />

</details> 