### PR TITLE
feat: Track and compare migrator lists in system data

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -374,6 +374,11 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 			httpError(w, r, fmt.Errorf("session out of date: existing version is greater"), http.StatusBadRequest)
 			return
 		}
+
+		if !savedata.ValidMigrators(data.System.AppliedMigrators, oldSystem.AppliedMigrators) {
+			httpError(w, r, fmt.Errorf("session out of date: migrators desynced"), http.StatusBadRequest)
+			return
+		}
 	}
 
 	existingSave, err := savedata.GetSession(db.Store, uuid, data.SessionSlotId)

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -505,6 +505,11 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 				httpError(w, r, fmt.Errorf("session out of date: existing version is greater"), http.StatusBadRequest)
 				return
 			}
+
+			if !savedata.ValidMigrators(system.AppliedMigrators, oldSystem.AppliedMigrators) {
+				httpError(w, r, fmt.Errorf("session out of date: migrators desynced"), http.StatusBadRequest)
+				return
+			}
 		}
 
 		err = savedata.UpdateSystem(db.Store, uuid, system)

--- a/api/savedata/utils.go
+++ b/api/savedata/utils.go
@@ -27,6 +27,17 @@ func CompareGameVersion(left string, right string) (int, error) {
 	return slices.Compare(leftTuple, rightTuple), nil
 }
 
+// Confirm that every migrator existing in the old save exists in the new save with identical timestamp
+func ValidMigrators(new map[string]int, old map[string]int) bool {
+	for migrator, timestamp := range old {
+		newTimestamp := new[migrator]
+		if newTimestamp != timestamp {
+			return false
+		}
+	}
+	return true
+}
+
 func parseGameVersion(version string) (VersionTuple, error) {
 	parts := strings.Split(version, ".")
 	if len(parts) < 3 || len(parts) > 4 {

--- a/defs/savedata.go
+++ b/defs/savedata.go
@@ -37,6 +37,7 @@ type SystemSaveData struct {
 	UnlockPity         []int              `json:"unlockPity"`
 	GameVersion        string             `json:"gameVersion"`
 	Timestamp          int                `json:"timestamp"`
+	AppliedMigrators   map[string]int     `json:"appliedMigrators"`
 }
 
 type DexData map[int]DexEntry


### PR DESCRIPTION
Added an `AppliedMigrators` field to the `SystemSaveData` struct, mirroring the changes in https://github.com/pagefaultgames/pokerogue/pull/7481. 

If the old data has any migrators stored which the new data has a different timestamp for (or none at all), the save is rejected. Saves with no migrators stored will have an empty map, in which case the check is effectively a no-op and returns true.