### PR TITLE
feat: Add tid/sid validation to system save update endpoint

### DIFF
--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -70,7 +70,7 @@ var ErrMigratorsDesynced = errors.New("session out of date: migrators desynced")
 // Otherwise, an http error will be generated and the caller should return immediately.
 //
 // Returns `nil` if the IDs are valid or were successfully created, otherwise returns an error indicating the issue.
-func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData defs.SystemSaveData) (code int, err error) {
+func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData defs.SystemSaveData) (int, error) {
 	storedTrainerId, storedSecretId, err := db.Store.FetchTrainerIds(uuid)
 	if err != nil {
 		return http.StatusInternalServerError, err

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -46,7 +46,7 @@ import (
 // Helper method that validates the trainer and secret IDs in the system save data against the database's
 // stored values.
 // If the stored values are not present, it will create them using the provided system save data.
-// Otherwise, an http error will be generated and
+// Otherwise, an http error will be generated and the caller should return immediately.
 //
 // Returns `true` if the IDs are valid or were successfully created. `false` means an http error was
 // generated and the caller should return immediately.
@@ -72,6 +72,11 @@ func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, sy
 	return true
 }
 
+// Helper method that ensures the client is sending a save with greater (or equal)
+// playtime than the existing save.
+//
+// Returns `true` if the IDs are valid or were successfully created. `false` means an http error was
+// generated and the caller should return immediately.
 func validatePlaytime(w http.ResponseWriter, r *http.Request, systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) bool {
 	playtime, ok := systemData.GameStats.(map[string]interface{})["playTime"].(float64)
 	if !ok {

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -70,23 +70,23 @@ var ErrMigratorsDesynced = errors.New("session out of date: migrators desynced")
 // Otherwise, an http error will be generated and the caller should return immediately.
 //
 // Returns `nil` if the IDs are valid or were successfully created, otherwise returns an error indicating the issue.
-func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData defs.SystemSaveData) (err error, code int) {
+func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData defs.SystemSaveData) (code int, err error) {
 	storedTrainerId, storedSecretId, err := db.Store.FetchTrainerIds(uuid)
 	if err != nil {
-		return err, http.StatusInternalServerError
+		return http.StatusInternalServerError, err
 	}
 
 	if storedTrainerId > 0 || storedSecretId > 0 {
 		if systemData.TrainerId != storedTrainerId || systemData.SecretId != storedSecretId {
-			return err, http.StatusBadRequest
+			return http.StatusBadRequest, ErrIdMismatch
 		}
 	} else {
 		err = db.Store.UpdateTrainerIds(systemData.TrainerId, systemData.SecretId, uuid)
 		if err != nil {
-			return err, http.StatusInternalServerError
+			return http.StatusInternalServerError, err
 		}
 	}
-	return nil, http.StatusOK
+	return http.StatusOK, nil
 }
 
 // Helper method that ensures the client is sending a save with greater (or equal)
@@ -406,7 +406,7 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err, code := validateOrCreateIds(w, r, uuid, data.System)
+	code, err := validateOrCreateIds(w, r, uuid, data.System)
 	if err != nil {
 		httpError(w, r, err, code)
 		return
@@ -527,7 +527,7 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		err, code := validateOrCreateIds(w, r, uuid, system)
+		code, err := validateOrCreateIds(w, r, uuid, system)
 		if err != nil {
 			httpError(w, r, err, code)
 			return

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -43,6 +43,89 @@ import (
 */
 // account
 
+// Helper method that validates the trainer and secret IDs in the system save data against the database's
+// stored values.
+// If the stored values are not present, it will create them using the provided system save data.
+// Otherwise, an http error will be generated and
+//
+// Returns `true` if the IDs are valid or were successfully created. `false` means an http error was
+// generated and the caller should return immediately.
+func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData *defs.SystemSaveData) bool {
+	storedTrainerId, storedSecretId, err := db.Store.FetchTrainerIds(uuid)
+	if err != nil {
+		httpError(w, r, err, http.StatusInternalServerError)
+		return false
+	}
+
+	if storedTrainerId > 0 || storedSecretId > 0 {
+		if systemData.TrainerId != storedTrainerId || systemData.SecretId != storedSecretId {
+			httpError(w, r, fmt.Errorf("session out of date: stored trainer or secret ID does not match"), http.StatusBadRequest)
+			return false
+		}
+	} else {
+		err = db.Store.UpdateTrainerIds(systemData.TrainerId, systemData.SecretId, uuid)
+		if err != nil {
+			httpError(w, r, err, http.StatusInternalServerError)
+			return false
+		}
+	}
+	return true
+}
+
+func validatePlaytime(w http.ResponseWriter, r *http.Request, systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) bool {
+	playtime, ok := systemData.GameStats.(map[string]interface{})["playTime"].(float64)
+	if !ok {
+		httpError(w, r, fmt.Errorf("no playtime found"), http.StatusBadRequest)
+		return false
+	}
+
+	oldPlaytime, ok := oldSystem.GameStats.(map[string]interface{})["playTime"].(float64)
+	if !ok {
+		httpError(w, r, fmt.Errorf("no playtime found"), http.StatusBadRequest)
+		return false
+	}
+
+	if playtime < oldPlaytime {
+		httpError(w, r, fmt.Errorf("session out of date: existing playtime is greater"), http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+// Helper method for validating the game version and applied migrators
+//
+// Returns `true` if the data is valid.
+//
+//	`false` means an http error was generated and the caller should return immediately.
+func validateSystemVersion(w http.ResponseWriter, r *http.Request, systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) bool {
+	minVerCmp, err := savedata.CompareGameVersion("1.12.0.10", systemData.GameVersion)
+	if err != nil {
+		httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
+		return false
+	}
+	if minVerCmp > 0 {
+		httpError(w, r, fmt.Errorf("session out of date: save version below minimum game version"), http.StatusBadRequest)
+		return false
+	}
+
+	saveVerCmp, err := savedata.CompareGameVersion(oldSystem.GameVersion, systemData.GameVersion)
+	if err != nil {
+		httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
+		return false
+	}
+	if saveVerCmp > 0 {
+		httpError(w, r, fmt.Errorf("session out of date: existing version is greater"), http.StatusBadRequest)
+		return false
+	}
+
+	if !savedata.ValidMigrators(systemData.AppliedMigrators, oldSystem.AppliedMigrators) {
+		httpError(w, r, fmt.Errorf("session out of date: migrators desynced"), http.StatusBadRequest)
+		return false
+	}
+
+	return true
+}
+
 func handleAccountInfo(w http.ResponseWriter, r *http.Request) {
 	uuid, err := uuidFromRequest(r)
 	if err != nil {
@@ -312,23 +395,8 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	storedTrainerId, storedSecretId, err := db.Store.FetchTrainerIds(uuid)
-	if err != nil {
-		httpError(w, r, err, http.StatusInternalServerError)
+	if !validateOrCreateIds(w, r, uuid, &data.System) {
 		return
-	}
-
-	if storedTrainerId > 0 || storedSecretId > 0 {
-		if data.System.TrainerId != storedTrainerId || data.System.SecretId != storedSecretId {
-			httpError(w, r, fmt.Errorf("session out of date: stored trainer or secret ID does not match"), http.StatusBadRequest)
-			return
-		}
-	} else {
-		err = db.Store.UpdateTrainerIds(data.System.TrainerId, data.System.SecretId, uuid)
-		if err != nil {
-			httpError(w, r, err, http.StatusInternalServerError)
-			return
-		}
 	}
 
 	oldSystem, err := savedata.GetSystem(db.Store, uuid)
@@ -338,45 +406,10 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		playtime, ok := data.System.GameStats.(map[string]interface{})["playTime"].(float64)
-		if !ok {
-			httpError(w, r, fmt.Errorf("no playtime found"), http.StatusBadRequest)
+		if !validatePlaytime(w, r, data.System, oldSystem) {
 			return
 		}
-
-		oldPlaytime, ok := oldSystem.GameStats.(map[string]interface{})["playTime"].(float64)
-		if !ok {
-			httpError(w, r, fmt.Errorf("no playtime found"), http.StatusBadRequest)
-			return
-		}
-
-		if playtime < oldPlaytime {
-			httpError(w, r, fmt.Errorf("session out of date: existing playtime is greater"), http.StatusBadRequest)
-			return
-		}
-
-		minVerCmp, err := savedata.CompareGameVersion("1.12.0.10", data.System.GameVersion)
-		if err != nil {
-			httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
-			return
-		}
-		if minVerCmp > 0 {
-			httpError(w, r, fmt.Errorf("session out of date: save version below minimum game version"), http.StatusBadRequest)
-			return
-		}
-
-		saveVerCmp, err := savedata.CompareGameVersion(oldSystem.GameVersion, data.System.GameVersion)
-		if err != nil {
-			httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
-			return
-		}
-		if saveVerCmp > 0 {
-			httpError(w, r, fmt.Errorf("session out of date: existing version is greater"), http.StatusBadRequest)
-			return
-		}
-
-		if !savedata.ValidMigrators(data.System.AppliedMigrators, oldSystem.AppliedMigrators) {
-			httpError(w, r, fmt.Errorf("session out of date: migrators desynced"), http.StatusBadRequest)
+		if !validateSystemVersion(w, r, data.System, oldSystem) {
 			return
 		}
 	}
@@ -458,7 +491,7 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 			httpError(w, r, fmt.Errorf("failed to compare versions: %s", cmpErr), http.StatusBadRequest)
 			return
 		}
-		if (versionCmp == 1 && save.AppliedMigrators["1.12.0.10-removeInvalidStarterAndDexData"] > 0) {
+		if versionCmp == 1 && save.AppliedMigrators["1.12.0.10-removeInvalidStarterAndDexData"] > 0 {
 			save.GameVersion = "1.12.0.10"
 		}
 
@@ -476,6 +509,10 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if !validateOrCreateIds(w, r, uuid, &system) {
+			return
+		}
+
 		oldSystem, err := savedata.GetSystem(db.Store, uuid)
 		if err != nil {
 			if !errors.Is(err, savedata.ErrSaveNotExist) {
@@ -483,45 +520,10 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			playtime, ok := system.GameStats.(map[string]interface{})["playTime"].(float64)
-			if !ok {
-				httpError(w, r, fmt.Errorf("no playtime found"), http.StatusBadRequest)
+			if !validatePlaytime(w, r, system, oldSystem) {
 				return
 			}
-
-			oldPlaytime, ok := oldSystem.GameStats.(map[string]interface{})["playTime"].(float64)
-			if !ok {
-				httpError(w, r, fmt.Errorf("no playtime found"), http.StatusBadRequest)
-				return
-			}
-
-			if playtime < oldPlaytime {
-				httpError(w, r, fmt.Errorf("session out of date: existing playtime is greater"), http.StatusBadRequest)
-				return
-			}
-
-			minVerCmp, err := savedata.CompareGameVersion("1.12.0.10", system.GameVersion)
-			if err != nil {
-				httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
-				return
-			}
-			if minVerCmp > 0 {
-				httpError(w, r, fmt.Errorf("session out of date: save version below minimum game version"), http.StatusBadRequest)
-				return
-			}
-
-			saveVerCmp, err := savedata.CompareGameVersion(oldSystem.GameVersion, system.GameVersion)
-			if err != nil {
-				httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
-				return
-			}
-			if saveVerCmp > 0 {
-				httpError(w, r, fmt.Errorf("session out of date: existing version is greater"), http.StatusBadRequest)
-				return
-			}
-
-			if !savedata.ValidMigrators(system.AppliedMigrators, oldSystem.AppliedMigrators) {
-				httpError(w, r, fmt.Errorf("session out of date: migrators desynced"), http.StatusBadRequest)
+			if !validateSystemVersion(w, r, system, oldSystem) {
 				return
 			}
 		}

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -50,7 +50,7 @@ import (
 //
 // Returns `true` if the IDs are valid or were successfully created. `false` means an http error was
 // generated and the caller should return immediately.
-func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData *defs.SystemSaveData) bool {
+func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData defs.SystemSaveData) bool {
 	storedTrainerId, storedSecretId, err := db.Store.FetchTrainerIds(uuid)
 	if err != nil {
 		httpError(w, r, err, http.StatusInternalServerError)
@@ -400,7 +400,7 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !validateOrCreateIds(w, r, uuid, &data.System) {
+	if !validateOrCreateIds(w, r, uuid, data.System) {
 		return
 	}
 
@@ -514,7 +514,7 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if !validateOrCreateIds(w, r, uuid, &system) {
+		if !validateOrCreateIds(w, r, uuid, system) {
 			return
 		}
 

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -36,6 +36,27 @@ import (
 	"github.com/pagefaultgames/rogueserver/defs"
 )
 
+// Issued when playtime is missing from the save data, indicating corruption or save tampering
+var ErrNoPlaytime = errors.New("no playtime found")
+
+// Issued when the tid/sid does not match database, indicating corruption or save tampering
+var ErrIdMismatch = errors.New("session out of date: stored trainer or secret ID does not match")
+
+// Issued when the playtime in the client save is lower than the server save, indicating an outdated save
+var ErrGreaterPlaytime = errors.New("session out of date: existing playtime is greater")
+
+// Issued when the client save version is lower than the minimum game version, indicating outdated client code
+var ErrVersionTooLow = errors.New("session out of date: save version below minimum game version")
+
+// Issued when the client save version is lower than the existing save version, indicating outdated client code
+var ErrExistingVersionGreater = errors.New("session out of date: existing version is greater")
+
+// Issued when version comparison fails, indicating a missing or malformed version string in the save data
+var ErrVersionCompare = errors.New("failed to compare versions")
+
+// Issued when migrator validation fails
+var ErrMigratorsDesynced = errors.New("session out of date: migrators desynced")
+
 /*
 	The caller of endpoint handler functions are responsible for extracting the necessary data from the request.
 	Handler functions are responsible for checking the validity of this data and returning a result or error.
@@ -48,87 +69,72 @@ import (
 // If the stored values are not present, it will create them using the provided system save data.
 // Otherwise, an http error will be generated and the caller should return immediately.
 //
-// Returns `true` if the IDs are valid or were successfully created. `false` means an http error was
-// generated and the caller should return immediately.
-func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData defs.SystemSaveData) bool {
+// Returns `nil` if the IDs are valid or were successfully created, otherwise returns an error indicating the issue.
+func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData defs.SystemSaveData) (err error, code int) {
 	storedTrainerId, storedSecretId, err := db.Store.FetchTrainerIds(uuid)
 	if err != nil {
-		httpError(w, r, err, http.StatusInternalServerError)
-		return false
+		return err, http.StatusInternalServerError
 	}
 
 	if storedTrainerId > 0 || storedSecretId > 0 {
 		if systemData.TrainerId != storedTrainerId || systemData.SecretId != storedSecretId {
-			httpError(w, r, fmt.Errorf("session out of date: stored trainer or secret ID does not match"), http.StatusBadRequest)
-			return false
+			return err, http.StatusBadRequest
 		}
 	} else {
 		err = db.Store.UpdateTrainerIds(systemData.TrainerId, systemData.SecretId, uuid)
 		if err != nil {
-			httpError(w, r, err, http.StatusInternalServerError)
-			return false
+			return err, http.StatusInternalServerError
 		}
 	}
-	return true
+	return nil, http.StatusOK
 }
 
 // Helper method that ensures the client is sending a save with greater (or equal)
 // playtime than the existing save.
 //
-// Returns `true` if the IDs are valid or were successfully created. `false` means an http error was
-// generated and the caller should return immediately.
-func validatePlaytime(w http.ResponseWriter, r *http.Request, systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) bool {
+// Returns `nil` if the playtime is valid, otherwise returns an error indicating the issue.
+func validatePlaytime(w http.ResponseWriter, r *http.Request, systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) error {
 	playtime, ok := systemData.GameStats.(map[string]interface{})["playTime"].(float64)
 	if !ok {
-		httpError(w, r, fmt.Errorf("no playtime found"), http.StatusBadRequest)
-		return false
+		return ErrNoPlaytime
 	}
 
 	oldPlaytime, ok := oldSystem.GameStats.(map[string]interface{})["playTime"].(float64)
 	if !ok {
-		httpError(w, r, fmt.Errorf("no playtime found"), http.StatusBadRequest)
-		return false
+		return ErrNoPlaytime
 	}
 
 	if playtime < oldPlaytime {
-		httpError(w, r, fmt.Errorf("session out of date: existing playtime is greater"), http.StatusBadRequest)
-		return false
+		return ErrGreaterPlaytime
 	}
-	return true
+	return nil
 }
 
 // Helper method for validating the game version and applied migrators
 //
-// Returns `true` if the data is valid.
-//
-//	`false` means an http error was generated and the caller should return immediately.
-func validateSystemVersion(w http.ResponseWriter, r *http.Request, systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) bool {
+// Returns `nil` if the version and migrators are valid, otherwise returns an error indicating the issue.
+func validateSystemVersion(w http.ResponseWriter, r *http.Request, systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) error {
 	minVerCmp, err := savedata.CompareGameVersion("1.12.0.10", systemData.GameVersion)
 	if err != nil {
-		httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
-		return false
+		return fmt.Errorf("%w: %w", ErrVersionCompare, err)
 	}
 	if minVerCmp > 0 {
-		httpError(w, r, fmt.Errorf("session out of date: save version below minimum game version"), http.StatusBadRequest)
-		return false
+		return ErrVersionTooLow
 	}
 
 	saveVerCmp, err := savedata.CompareGameVersion(oldSystem.GameVersion, systemData.GameVersion)
 	if err != nil {
-		httpError(w, r, fmt.Errorf("failed to compare versions: %s", err), http.StatusBadRequest)
-		return false
+		return fmt.Errorf("%w: %w", ErrVersionCompare, err)
 	}
 	if saveVerCmp > 0 {
-		httpError(w, r, fmt.Errorf("session out of date: existing version is greater"), http.StatusBadRequest)
-		return false
+		return ErrExistingVersionGreater
 	}
 
 	if !savedata.ValidMigrators(systemData.AppliedMigrators, oldSystem.AppliedMigrators) {
-		httpError(w, r, fmt.Errorf("session out of date: migrators desynced"), http.StatusBadRequest)
-		return false
+		return ErrMigratorsDesynced
 	}
 
-	return true
+	return nil
 }
 
 func handleAccountInfo(w http.ResponseWriter, r *http.Request) {
@@ -400,7 +406,9 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !validateOrCreateIds(w, r, uuid, data.System) {
+	err, code := validateOrCreateIds(w, r, uuid, data.System)
+	if err != nil {
+		httpError(w, r, err, code)
 		return
 	}
 
@@ -411,10 +419,15 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		if !validatePlaytime(w, r, data.System, oldSystem) {
+		err = validatePlaytime(w, r, data.System, oldSystem)
+		if err != nil {
+			httpError(w, r, err, http.StatusBadRequest)
 			return
 		}
-		if !validateSystemVersion(w, r, data.System, oldSystem) {
+
+		err = validateSystemVersion(w, r, data.System, oldSystem)
+		if err != nil {
+			httpError(w, r, err, http.StatusBadRequest)
 			return
 		}
 	}
@@ -514,7 +527,9 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if !validateOrCreateIds(w, r, uuid, system) {
+		err, code := validateOrCreateIds(w, r, uuid, system)
+		if err != nil {
+			httpError(w, r, err, code)
 			return
 		}
 
@@ -525,10 +540,14 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			if !validatePlaytime(w, r, system, oldSystem) {
+			err = validatePlaytime(w, r, system, oldSystem)
+			if err != nil {
+				httpError(w, r, err, http.StatusBadRequest)
 				return
 			}
-			if !validateSystemVersion(w, r, system, oldSystem) {
+			err = validateSystemVersion(w, r, system, oldSystem)
+			if err != nil {
+				httpError(w, r, err, http.StatusBadRequest)
 				return
 			}
 		}

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -70,7 +70,7 @@ var ErrMigratorsDesynced = errors.New("session out of date: migrators desynced")
 // Otherwise, an http error will be generated and the caller should return immediately.
 //
 // Returns `nil` if the IDs are valid or were successfully created, otherwise returns an error indicating the issue.
-func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, systemData defs.SystemSaveData) (int, error) {
+func validateOrCreateIds(uuid []byte, systemData defs.SystemSaveData) (int, error) {
 	storedTrainerId, storedSecretId, err := db.Store.FetchTrainerIds(uuid)
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -93,7 +93,7 @@ func validateOrCreateIds(w http.ResponseWriter, r *http.Request, uuid []byte, sy
 // playtime than the existing save.
 //
 // Returns `nil` if the playtime is valid, otherwise returns an error indicating the issue.
-func validatePlaytime(w http.ResponseWriter, r *http.Request, systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) error {
+func validatePlaytime(systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) error {
 	playtime, ok := systemData.GameStats.(map[string]interface{})["playTime"].(float64)
 	if !ok {
 		return ErrNoPlaytime
@@ -113,7 +113,7 @@ func validatePlaytime(w http.ResponseWriter, r *http.Request, systemData defs.Sy
 // Helper method for validating the game version and applied migrators
 //
 // Returns `nil` if the version and migrators are valid, otherwise returns an error indicating the issue.
-func validateSystemVersion(w http.ResponseWriter, r *http.Request, systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) error {
+func validateSystemVersion(systemData defs.SystemSaveData, oldSystem defs.SystemSaveData) error {
 	minVerCmp, err := savedata.CompareGameVersion("1.12.0.10", systemData.GameVersion)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrVersionCompare, err)
@@ -406,7 +406,7 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	code, err := validateOrCreateIds(w, r, uuid, data.System)
+	code, err := validateOrCreateIds(uuid, data.System)
 	if err != nil {
 		httpError(w, r, err, code)
 		return
@@ -419,13 +419,13 @@ func handleUpdateAll(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		err = validatePlaytime(w, r, data.System, oldSystem)
+		err = validatePlaytime(data.System, oldSystem)
 		if err != nil {
 			httpError(w, r, err, http.StatusBadRequest)
 			return
 		}
 
-		err = validateSystemVersion(w, r, data.System, oldSystem)
+		err = validateSystemVersion(data.System, oldSystem)
 		if err != nil {
 			httpError(w, r, err, http.StatusBadRequest)
 			return
@@ -527,7 +527,7 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		code, err := validateOrCreateIds(w, r, uuid, system)
+		code, err := validateOrCreateIds(uuid, system)
 		if err != nil {
 			httpError(w, r, err, code)
 			return
@@ -540,12 +540,12 @@ func handleSystem(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			err = validatePlaytime(w, r, system, oldSystem)
+			err = validatePlaytime(system, oldSystem)
 			if err != nil {
 				httpError(w, r, err, http.StatusBadRequest)
 				return
 			}
-			err = validateSystemVersion(w, r, system, oldSystem)
+			err = validateSystemVersion(system, oldSystem)
 			if err != nil {
 				httpError(w, r, err, http.StatusBadRequest)
 				return


### PR DESCRIPTION
Add tid/sid validation to the system save endpoint as it is done in the updateAll endpoint.

This addresses an issue that would allow a malformed or modified save to send a save with a tid/sid that didn't match the database record, preventing the user from saving any data.

As part of this change, extracted out logic shared between the `updateAll` method and the `update` case block in the `handleSystem` method for DRYness.